### PR TITLE
バレルファイルインポートの廃止 (#5)

### DIFF
--- a/stacks/react-nodejs/frontend/src/app/App.tsx
+++ b/stacks/react-nodejs/frontend/src/app/App.tsx
@@ -8,8 +8,9 @@ import SignInPage from "./pages/SignInPage";
 import SignUpPage from "./pages/SignUpPage";
 import TodoPage from "./pages/TodoPage";
 
-import { AppManagerProvider } from "@/contexts/AppManager";
-import { AuthRoute, SignOutButton } from "@/features/auths";
+import AppManagerProvider from "@/contexts/AppManager/AppManagerProvider";
+import AuthRoute from "@/features/auths/components/AuthRoute";
+import SignOutButton from "@/features/auths/components/SignOutButton";
 
 const App: React.FC = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/app/pages/DailyPlanPage.tsx
+++ b/stacks/react-nodejs/frontend/src/app/pages/DailyPlanPage.tsx
@@ -1,5 +1,5 @@
-import { SignOutButton } from "@/features/auths";
-import { DailyPlanList } from "@/features/daily-plans";
+import SignOutButton from "@/features/auths/components/SignOutButton";
+import DailyPlanList from "@/features/daily-plans/components/DailyPlanList";
 
 const DailyPlanPage = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/app/pages/HabitPage.tsx
+++ b/stacks/react-nodejs/frontend/src/app/pages/HabitPage.tsx
@@ -1,5 +1,5 @@
-import { SignOutButton } from "@/features/auths";
-import { HabitList } from "@/features/habits";
+import SignOutButton from "@/features/auths/components/SignOutButton";
+import HabitList from "@/features/habits/components/HabitList";
 
 const HabitPage = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/app/pages/SignInPage.tsx
+++ b/stacks/react-nodejs/frontend/src/app/pages/SignInPage.tsx
@@ -1,7 +1,7 @@
 import { PagePath } from "@1day-todo/shared";
 import { Link } from "react-router-dom";
 
-import { SignInForm } from "@/features/auths";
+import SignInForm from "@/features/auths/components/SignInForm";
 
 const SignInPage: React.FC = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/app/pages/SignUpPage.tsx
+++ b/stacks/react-nodejs/frontend/src/app/pages/SignUpPage.tsx
@@ -1,4 +1,4 @@
-import { SignUpForm } from "@/features/auths";
+import SignUpForm from "@/features/auths/components/SignUpForm";
 
 const SignUpPage: React.FC = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/app/pages/TodoPage.tsx
+++ b/stacks/react-nodejs/frontend/src/app/pages/TodoPage.tsx
@@ -1,5 +1,5 @@
-import { SignOutButton } from "@/features/auths";
-import { TodoList } from "@/features/todos";
+import SignOutButton from "@/features/auths/components/SignOutButton";
+import TodoList from "@/features/todos/components/TodoList";
 
 const TodoPage = () => {
     return (

--- a/stacks/react-nodejs/frontend/src/contexts/AppManager/AppLayer.ts
+++ b/stacks/react-nodejs/frontend/src/contexts/AppManager/AppLayer.ts
@@ -1,12 +1,12 @@
 import { Layer } from "effect";
 
 import { AuthLive } from "@/features/auths/services/AuthLive";
-import { DailyPlanLive } from "@/features/daily-plans";
-import { HabitLive } from "@/features/habits";
-import { TodoLive } from "@/features/todos";
-import { ApiLive } from "@/shared/http";
-import { ConsoleLoggerLive } from "@/shared/logger";
-import { UILive } from "@/shared/ui";
+import { DailyPlanLive } from "@/features/daily-plans/services/DailyPlanLive";
+import { HabitLive } from "@/features/habits/services/HabitLive";
+import { TodoLive } from "@/features/todos/services/TodoLive";
+import { ApiLive } from "@/shared/http/services/ApiLive";
+import { ConsoleLoggerLive } from "@/shared/logger/services/ConsoleLoggerLive";
+import { UILive } from "@/shared/ui/services/UILive";
 
 export const AppLayer = Layer.mergeAll(
     ApiLive,

--- a/stacks/react-nodejs/frontend/src/contexts/AppManager/AppManagerProvider.tsx
+++ b/stacks/react-nodejs/frontend/src/contexts/AppManager/AppManagerProvider.tsx
@@ -14,8 +14,10 @@ const createAppManager = (): IAppManager => {
     };
 };
 
-export const AppManagerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const AppManagerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const appManager = useMemo(() => createAppManager(), []);
 
     return <AppManagerContext value={appManager}>{children}</AppManagerContext>;
 };
+
+export default AppManagerProvider;

--- a/stacks/react-nodejs/frontend/src/contexts/AppManager/index.ts
+++ b/stacks/react-nodejs/frontend/src/contexts/AppManager/index.ts
@@ -1,3 +1,0 @@
-export { AppManagerContext } from "./AppManagerContext";
-export { AppManagerProvider } from "./AppManagerProvider";
-export type { IAppManager } from "./IAppManager";

--- a/stacks/react-nodejs/frontend/src/errors/index.ts
+++ b/stacks/react-nodejs/frontend/src/errors/index.ts
@@ -1,3 +1,0 @@
-export * from "./types/AppError";
-export * from "./types/features";
-export * from "./types/shared";

--- a/stacks/react-nodejs/frontend/src/errors/types/AppError.ts
+++ b/stacks/react-nodejs/frontend/src/errors/types/AppError.ts
@@ -1,4 +1,7 @@
-import { AuthError, DomainUtilError, SettingError, TaskError } from "./features";
-import { SharedError } from "./shared";
+import { AuthError } from "./features/AuthError";
+import { DomainUtilError } from "./features/DomainUtilError";
+import { SettingError } from "./features/SettingError";
+import { TaskError } from "./features/TaskError";
+import { SharedError } from "./shared/SharedError";
 
 export type AppError = SharedError | AuthError | SettingError | TaskError | DomainUtilError;

--- a/stacks/react-nodejs/frontend/src/errors/types/features/DomainUtilError.ts
+++ b/stacks/react-nodejs/frontend/src/errors/types/features/DomainUtilError.ts
@@ -1,6 +1,6 @@
 import { Cause, Data } from "effect";
 
-import { SharedError } from "../shared";
+import { SharedError } from "../shared/SharedError";
 
 export class InternalServerError extends Data.TaggedError("InternalServerError")<{
     message: string;

--- a/stacks/react-nodejs/frontend/src/errors/types/features/index.ts
+++ b/stacks/react-nodejs/frontend/src/errors/types/features/index.ts
@@ -1,4 +1,0 @@
-export * from "./AuthError";
-export * from "./DomainUtilError";
-export * from "./SettingError";
-export * from "./TaskError";

--- a/stacks/react-nodejs/frontend/src/errors/types/shared/index.ts
+++ b/stacks/react-nodejs/frontend/src/errors/types/shared/index.ts
@@ -1,4 +1,0 @@
-export * from "./HttpError";
-export * from "./OtherError";
-export * from "./SharedError";
-export * from "./UIError";

--- a/stacks/react-nodejs/frontend/src/features/auths/components/SignInForm.tsx
+++ b/stacks/react-nodejs/frontend/src/features/auths/components/SignInForm.tsx
@@ -4,12 +4,12 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../hooks/useAuth";
 
+import { InvalidCredentialsError } from "@/errors/types/features/AuthError";
 import {
     CriticalError,
     InternalServerError,
-    InvalidCredentialsError,
     ValidationError,
-} from "@/errors";
+} from "@/errors/types/features/DomainUtilError";
 
 const SignInForm: React.FC = () => {
     const methods = useForm<{ email: string; password: string }>();

--- a/stacks/react-nodejs/frontend/src/features/auths/components/SignUpForm.tsx
+++ b/stacks/react-nodejs/frontend/src/features/auths/components/SignUpForm.tsx
@@ -6,7 +6,11 @@ import { useSignUp } from "../hooks/useSignUp";
 
 import SignUpSuccessMessage from "./SignUpSuccessMessage";
 
-import { CriticalError, InternalServerError, ValidationError } from "@/errors";
+import {
+    CriticalError,
+    InternalServerError,
+    ValidationError,
+} from "@/errors/types/features/DomainUtilError";
 
 const SignUpForm: React.FC = () => {
     const methods = useForm<{ email: string; password: string }>();

--- a/stacks/react-nodejs/frontend/src/features/auths/hooks/useAuth.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/hooks/useAuth.ts
@@ -4,15 +4,14 @@ import { Exit } from "effect";
 
 import { checkSessionUseCase, signInUseCase, signOutUseCase } from "../services/use-cases";
 
+import { InvalidCredentialsError, InvalidSessionError } from "@/errors/types/features/AuthError";
 import {
     CriticalError,
     InternalServerError,
-    InvalidCredentialsError,
-    InvalidSessionError,
     ValidationError,
-} from "@/errors";
-import { useAppManager } from "@/shared/app";
-import { handleCause } from "@/shared/utils";
+} from "@/errors/types/features/DomainUtilError";
+import { useAppManager } from "@/shared/app/useAppManager";
+import { handleCause } from "@/shared/utils/handleExit";
 
 const AUTH_SESSION_QUERY_KEY = ["authSession"];
 

--- a/stacks/react-nodejs/frontend/src/features/auths/hooks/useSignUp.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/hooks/useSignUp.ts
@@ -4,9 +4,13 @@ import { Exit } from "effect";
 
 import { signUpUseCase } from "../services/use-cases";
 
-import { CriticalError, InternalServerError, ValidationError } from "@/errors";
+import {
+    CriticalError,
+    InternalServerError,
+    ValidationError,
+} from "@/errors/types/features/DomainUtilError";
 import { useAppManager } from "@/shared/app/useAppManager";
-import { handleCause } from "@/shared/utils";
+import { handleCause } from "@/shared/utils/handleExit";
 
 export const useSignUp = () => {
     const { runPromise } = useAppManager();

--- a/stacks/react-nodejs/frontend/src/features/auths/index.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/index.ts
@@ -1,4 +1,0 @@
-export { default as AuthRoute } from "./components/AuthRoute";
-export { default as SignInForm } from "./components/SignInForm";
-export { default as SignOutButton } from "./components/SignOutButton";
-export { default as SignUpForm } from "./components/SignUpForm";

--- a/stacks/react-nodejs/frontend/src/features/auths/services/AuthLive.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/services/AuthLive.ts
@@ -3,8 +3,11 @@ import { Effect, Layer, pipe } from "effect";
 
 import { AuthService } from "./AuthService";
 
-import { InternalServerError, InvalidCredentialsError, InvalidSessionError } from "@/errors";
-import { ApiService, extractBodyWithSchema, HttpStatus } from "@/shared/http";
+import { InvalidCredentialsError, InvalidSessionError } from "@/errors/types/features/AuthError";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
+import { extractBodyWithSchema } from "@/shared/http/services/use-case";
+import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 export const AuthLive = Layer.succeed(
     AuthService,

--- a/stacks/react-nodejs/frontend/src/features/auths/services/AuthService.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/services/AuthService.ts
@@ -1,8 +1,9 @@
 import { SignInInput, SignUpInput, UserId } from "@1day-todo/shared";
 import { Effect } from "effect";
 
-import { InternalServerError, InvalidCredentialsError, InvalidSessionError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InvalidCredentialsError, InvalidSessionError } from "@/errors/types/features/AuthError";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export interface IAuthService {
     readonly checkSession: () => Effect.Effect<

--- a/stacks/react-nodejs/frontend/src/features/auths/services/use-cases.ts
+++ b/stacks/react-nodejs/frontend/src/features/auths/services/use-cases.ts
@@ -9,13 +9,9 @@ import { Effect, pipe, Schema } from "effect";
 
 import { AuthService } from "./AuthService";
 
-import {
-    InternalServerError,
-    InvalidCredentialsError,
-    InvalidSessionError,
-    ValidationError,
-} from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InvalidCredentialsError, InvalidSessionError } from "@/errors/types/features/AuthError";
+import { InternalServerError, ValidationError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export const checkSessionUseCase = (): Effect.Effect<
     UserId,

--- a/stacks/react-nodejs/frontend/src/features/daily-plans/components/DailyPlanList.tsx
+++ b/stacks/react-nodejs/frontend/src/features/daily-plans/components/DailyPlanList.tsx
@@ -4,8 +4,8 @@ import { Cause, Exit, Option } from "effect";
 
 import { getAllDailyPlansUseCase } from "../services/use-cases";
 
-import { TaskUnknownError } from "@/errors";
-import { useAppManager } from "@/shared/app";
+import { TaskUnknownError } from "@/errors/types/features/TaskError";
+import { useAppManager } from "@/shared/app/useAppManager";
 import Tasks from "@/shared/components/Tasks";
 
 export const DailyPlanList = () => {

--- a/stacks/react-nodejs/frontend/src/features/daily-plans/index.ts
+++ b/stacks/react-nodejs/frontend/src/features/daily-plans/index.ts
@@ -1,2 +1,0 @@
-export { default as DailyPlanList } from "./components/DailyPlanList";
-export { DailyPlanLive } from "./services/DailyPlanLive";

--- a/stacks/react-nodejs/frontend/src/features/daily-plans/services/DailyPlanLive.ts
+++ b/stacks/react-nodejs/frontend/src/features/daily-plans/services/DailyPlanLive.ts
@@ -3,8 +3,10 @@ import { Effect, Layer, pipe } from "effect";
 
 import { DailyPlanService } from "./DailyPlanService";
 
-import { InternalServerError } from "@/errors";
-import { ApiService, extractBodyWithSchema, HttpStatus } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
+import { extractBodyWithSchema } from "@/shared/http/services/use-case";
+import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 export const DailyPlanLive = Layer.succeed(
     DailyPlanService,

--- a/stacks/react-nodejs/frontend/src/features/daily-plans/services/DailyPlanService.ts
+++ b/stacks/react-nodejs/frontend/src/features/daily-plans/services/DailyPlanService.ts
@@ -1,8 +1,8 @@
 import { DailyPlan } from "@1day-todo/shared";
 import { Chunk, Effect } from "effect";
 
-import { InternalServerError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export interface IDailyPlanService {
     readonly getAllDailyPlansApi: () => Effect.Effect<

--- a/stacks/react-nodejs/frontend/src/features/daily-plans/services/use-cases.ts
+++ b/stacks/react-nodejs/frontend/src/features/daily-plans/services/use-cases.ts
@@ -3,8 +3,8 @@ import { Effect, pipe, Schema } from "effect";
 
 import { DailyPlanService } from "./DailyPlanService";
 
-import { InternalServerError, ValidationError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError, ValidationError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export const getAllDailyPlansUseCase = (): Effect.Effect<
     DailyPlanChunk,

--- a/stacks/react-nodejs/frontend/src/features/habits/hooks/useHabit.ts
+++ b/stacks/react-nodejs/frontend/src/features/habits/hooks/useHabit.ts
@@ -15,9 +15,13 @@ import {
     updateHabitUseCase,
 } from "../services/use-cases";
 
-import { CriticalError, InternalServerError, ValidationError } from "@/errors";
-import { useAppManager } from "@/shared/app";
-import { handleCause } from "@/shared/utils";
+import {
+    CriticalError,
+    InternalServerError,
+    ValidationError,
+} from "@/errors/types/features/DomainUtilError";
+import { useAppManager } from "@/shared/app/useAppManager";
+import { handleCause } from "@/shared/utils/handleExit";
 
 const HABIT_QUERY_KEY = ["habitChunk"];
 

--- a/stacks/react-nodejs/frontend/src/features/habits/index.ts
+++ b/stacks/react-nodejs/frontend/src/features/habits/index.ts
@@ -1,2 +1,0 @@
-export { default as HabitList } from "./components/HabitList";
-export { HabitLive } from "./services/HabitLive";

--- a/stacks/react-nodejs/frontend/src/features/habits/services/HabitLive.ts
+++ b/stacks/react-nodejs/frontend/src/features/habits/services/HabitLive.ts
@@ -3,8 +3,10 @@ import { Effect, Layer, pipe, Schema } from "effect";
 
 import { HabitService } from "./HabitService";
 
-import { InternalServerError } from "@/errors";
-import { ApiService, extractBodyWithSchema, HttpStatus } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
+import { extractBodyWithSchema } from "@/shared/http/services/use-case";
+import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 export const HabitLive = Layer.succeed(
     HabitService,

--- a/stacks/react-nodejs/frontend/src/features/habits/services/HabitService.ts
+++ b/stacks/react-nodejs/frontend/src/features/habits/services/HabitService.ts
@@ -1,8 +1,8 @@
 import { Habit, HabitChunk, HabitCreate, HabitUpdate } from "@1day-todo/shared";
 import { Effect } from "effect";
 
-import { InternalServerError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export interface IHabitService {
     readonly getAllHabitsApi: () => Effect.Effect<HabitChunk, InternalServerError, ApiService>;

--- a/stacks/react-nodejs/frontend/src/features/habits/services/use-cases.ts
+++ b/stacks/react-nodejs/frontend/src/features/habits/services/use-cases.ts
@@ -10,8 +10,8 @@ import { Effect, pipe, Schema } from "effect";
 
 import { HabitService } from "./HabitService";
 
-import { InternalServerError, ValidationError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError, ValidationError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export const getAllHabitsUseCase = (): Effect.Effect<
     HabitChunk,

--- a/stacks/react-nodejs/frontend/src/features/settings/services/SettingLive.ts
+++ b/stacks/react-nodejs/frontend/src/features/settings/services/SettingLive.ts
@@ -3,7 +3,9 @@ import { Effect, Layer, pipe } from "effect";
 
 import { SettingService } from "./SettingService";
 
-import { ApiService, extractBodyWithSchema, HttpStatus } from "@/shared/http";
+import { ApiService } from "@/shared/http/services/ApiService";
+import { extractBodyWithSchema } from "@/shared/http/services/use-case";
+import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 export const SettingLive = Layer.succeed(
     SettingService,

--- a/stacks/react-nodejs/frontend/src/features/settings/services/SettingService.ts
+++ b/stacks/react-nodejs/frontend/src/features/settings/services/SettingService.ts
@@ -1,8 +1,8 @@
 import { SettingsInput, SettingsOutput } from "@1day-todo/shared";
 import { Effect } from "effect";
 
-import { SharedError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { SharedError } from "@/errors/types/shared/SharedError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 interface ISettingService {
     readonly getSettingsApi: () => Effect.Effect<SettingsOutput, SharedError, ApiService>;

--- a/stacks/react-nodejs/frontend/src/features/todos/hooks/useTodo.ts
+++ b/stacks/react-nodejs/frontend/src/features/todos/hooks/useTodo.ts
@@ -15,9 +15,13 @@ import {
     updateTodoUseCase,
 } from "../services/use-cases";
 
-import { CriticalError, InternalServerError, ValidationError } from "@/errors";
-import { useAppManager } from "@/shared/app";
-import { handleCause } from "@/shared/utils";
+import {
+    CriticalError,
+    InternalServerError,
+    ValidationError,
+} from "@/errors/types/features/DomainUtilError";
+import { useAppManager } from "@/shared/app/useAppManager";
+import { handleCause } from "@/shared/utils/handleExit";
 
 const TODO_QUERY_KEY = ["todoChunk"];
 

--- a/stacks/react-nodejs/frontend/src/features/todos/index.ts
+++ b/stacks/react-nodejs/frontend/src/features/todos/index.ts
@@ -1,2 +1,0 @@
-export { default as TodoList } from "./components/TodoList";
-export { TodoLive } from "./services/TodoLive";

--- a/stacks/react-nodejs/frontend/src/features/todos/services/TodoLive.ts
+++ b/stacks/react-nodejs/frontend/src/features/todos/services/TodoLive.ts
@@ -3,8 +3,10 @@ import { Effect, Layer, pipe, Schema } from "effect";
 
 import { TodoService } from "./TodoService";
 
-import { InternalServerError } from "@/errors";
-import { ApiService, extractBodyWithSchema, HttpStatus } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
+import { extractBodyWithSchema } from "@/shared/http/services/use-case";
+import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 export const TodoLive = Layer.succeed(
     TodoService,

--- a/stacks/react-nodejs/frontend/src/features/todos/services/TodoService.ts
+++ b/stacks/react-nodejs/frontend/src/features/todos/services/TodoService.ts
@@ -1,8 +1,8 @@
 import { Todo, TodoChunk, TodoCreate, TodoUpdate } from "@1day-todo/shared";
 import { Effect } from "effect";
 
-import { InternalServerError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export interface ITodoService {
     readonly getAllTodosApi: () => Effect.Effect<TodoChunk, InternalServerError, ApiService>;

--- a/stacks/react-nodejs/frontend/src/features/todos/services/use-cases.ts
+++ b/stacks/react-nodejs/frontend/src/features/todos/services/use-cases.ts
@@ -10,8 +10,8 @@ import { Effect, pipe, Schema } from "effect";
 
 import { TodoService } from "./TodoService";
 
-import { InternalServerError, ValidationError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { InternalServerError, ValidationError } from "@/errors/types/features/DomainUtilError";
+import { ApiService } from "@/shared/http/services/ApiService";
 
 export const getAllTodosUseCase = (): Effect.Effect<
     TodoChunk,

--- a/stacks/react-nodejs/frontend/src/shared/app/index.ts
+++ b/stacks/react-nodejs/frontend/src/shared/app/index.ts
@@ -1,1 +1,0 @@
-export { useAppManager } from "./useAppManager";

--- a/stacks/react-nodejs/frontend/src/shared/app/useAppManager.ts
+++ b/stacks/react-nodejs/frontend/src/shared/app/useAppManager.ts
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
-import { AppManagerContext, IAppManager } from "@/contexts/AppManager";
+import { AppManagerContext } from "@/contexts/AppManager/AppManagerContext";
+import { IAppManager } from "@/contexts/AppManager/IAppManager";
 
 export const useAppManager = (): IAppManager => {
     const context = useContext(AppManagerContext);

--- a/stacks/react-nodejs/frontend/src/shared/http/index.ts
+++ b/stacks/react-nodejs/frontend/src/shared/http/index.ts
@@ -1,4 +1,0 @@
-export { ApiLive } from "./services/ApiLive";
-export { ApiService } from "./services/ApiService";
-export { extractBodyWithSchema } from "./services/use-case";
-export { HttpStatus } from "./types/HttpStatus";

--- a/stacks/react-nodejs/frontend/src/shared/http/services/ApiLive.ts
+++ b/stacks/react-nodejs/frontend/src/shared/http/services/ApiLive.ts
@@ -6,7 +6,7 @@ import { HttpStatus } from "../types/HttpStatus";
 import { ApiService } from "./ApiService";
 import { ensureHttpStatus, handleHttpError } from "./helper";
 
-import { NetworkError, ResponseJsonError } from "@/errors";
+import { NetworkError, ResponseJsonError } from "@/errors/types/shared/OtherError";
 
 const getApiUrl = (path: string): string => {
     const baseUrl = import.meta.env.VITE_API_URL || "";

--- a/stacks/react-nodejs/frontend/src/shared/http/services/ApiService.ts
+++ b/stacks/react-nodejs/frontend/src/shared/http/services/ApiService.ts
@@ -3,7 +3,8 @@ import { Effect } from "effect";
 import { PostOptionType } from "../types/api-types";
 import { HttpStatus } from "../types/HttpStatus";
 
-import { HttpError, NetworkError, ResponseJsonError } from "@/errors";
+import { HttpError } from "@/errors/types/shared/HttpError";
+import { NetworkError, ResponseJsonError } from "@/errors/types/shared/OtherError";
 
 export interface IApiService {
     readonly get: (

--- a/stacks/react-nodejs/frontend/src/shared/http/services/helper.ts
+++ b/stacks/react-nodejs/frontend/src/shared/http/services/helper.ts
@@ -12,7 +12,7 @@ import {
     HttpUnauthorizedError,
     HttpUnexpectedStatusError,
     HttpUnknownError,
-} from "@/errors";
+} from "@/errors/types/shared/HttpError";
 
 interface ErrorInfo {
     readonly path: string;

--- a/stacks/react-nodejs/frontend/src/shared/http/services/use-case.ts
+++ b/stacks/react-nodejs/frontend/src/shared/http/services/use-case.ts
@@ -2,7 +2,7 @@ import { Effect, ParseResult, pipe, Schema } from "effect";
 
 import { ApiService } from "./ApiService";
 
-import { ResponseJsonError } from "@/errors";
+import { ResponseJsonError } from "@/errors/types/shared/OtherError";
 
 export const extractBodyWithSchema =
     <A, I>(

--- a/stacks/react-nodejs/frontend/src/shared/logger/index.ts
+++ b/stacks/react-nodejs/frontend/src/shared/logger/index.ts
@@ -1,2 +1,0 @@
-export { LoggerService } from "./services/LoggerService";
-export { ConsoleLoggerLive } from "./services/ConsoleLoggerLive";

--- a/stacks/react-nodejs/frontend/src/shared/logger/services/ConsoleLoggerLive.ts
+++ b/stacks/react-nodejs/frontend/src/shared/logger/services/ConsoleLoggerLive.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect";
 
-import { LoggerService } from "@/shared/logger";
+import { LoggerService } from "./LoggerService";
 
 export const consoleLogger = {
     log: (message: string, ...args: unknown[]) =>

--- a/stacks/react-nodejs/frontend/src/shared/ui/index.ts
+++ b/stacks/react-nodejs/frontend/src/shared/ui/index.ts
@@ -1,6 +1,0 @@
-export { createButton } from "./components/button";
-export { buildFooter } from "./components/footer";
-export { buildHeader } from "./components/header";
-export { UILive } from "./services/UILive";
-export { UIService } from "./services/UIService";
-export { appendElementsWrapper } from "./services/use-case";

--- a/stacks/react-nodejs/frontend/src/shared/ui/services/UILive.ts
+++ b/stacks/react-nodejs/frontend/src/shared/ui/services/UILive.ts
@@ -2,7 +2,7 @@ import { Chunk, Effect, Either, Layer, Option, pipe } from "effect";
 
 import { UIService } from "./UIService";
 
-import { AppendElementsError, UIUnknownError } from "@/errors";
+import { AppendElementsError, UIUnknownError } from "@/errors/types/shared/UIError";
 
 export const UILive = Layer.succeed(
     UIService,

--- a/stacks/react-nodejs/frontend/src/shared/ui/services/UIService.ts
+++ b/stacks/react-nodejs/frontend/src/shared/ui/services/UIService.ts
@@ -1,7 +1,7 @@
 import { PagePath } from "@1day-todo/shared";
 import { Chunk, Effect } from "effect";
 
-import { AppendElementsError, UIUnknownError } from "@/errors";
+import { AppendElementsError, UIUnknownError } from "@/errors/types/shared/UIError";
 
 interface IUIService {
     readonly getElementById: (id: string) => Effect.Effect<HTMLElement, UIUnknownError>;

--- a/stacks/react-nodejs/frontend/src/shared/ui/services/use-case.ts
+++ b/stacks/react-nodejs/frontend/src/shared/ui/services/use-case.ts
@@ -2,7 +2,7 @@ import { Chunk, Effect } from "effect";
 
 import { UIService } from "./UIService";
 
-import { AppendElementsError } from "@/errors";
+import { AppendElementsError } from "@/errors/types/shared/UIError";
 
 export const appendElementsWrapper = (
     parent: HTMLElement,

--- a/stacks/react-nodejs/frontend/src/shared/utils/handleExit.ts
+++ b/stacks/react-nodejs/frontend/src/shared/utils/handleExit.ts
@@ -1,7 +1,7 @@
 import { Cause, Option } from "effect";
 import { YieldableError } from "effect/Cause";
 
-import { CriticalError } from "@/errors";
+import { CriticalError } from "@/errors/types/features/DomainUtilError";
 
 export const handleCause = <E1 extends YieldableError>(
     cause: Cause.Cause<E1>,

--- a/stacks/react-nodejs/frontend/src/shared/utils/index.ts
+++ b/stacks/react-nodejs/frontend/src/shared/utils/index.ts
@@ -1,1 +1,0 @@
-export { handleCause } from "./handleExit";

--- a/stacks/react-nodejs/frontend/tests/core/http/services/ApiLive.test.ts
+++ b/stacks/react-nodejs/frontend/tests/core/http/services/ApiLive.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "@effect/vitest"
 import { Effect } from "effect";
 import { validateAppError } from "tests/test-utils";
 
-import { HttpError } from "@/errors";
-import { ApiService } from "@/shared/http";
+import { HttpError } from "@/errors/types/shared/HttpError";
 import { ApiLive } from "@/shared/http/services/ApiLive";
+import { ApiService } from "@/shared/http/services/ApiService";
 import { HttpStatus } from "@/shared/http/types/HttpStatus";
 
 // global.fetch のモック

--- a/stacks/react-nodejs/frontend/tests/core/http/services/helper.test.ts
+++ b/stacks/react-nodejs/frontend/tests/core/http/services/helper.test.ts
@@ -10,7 +10,7 @@ import {
     HttpOtherServerError,
     HttpUnauthorizedError,
     HttpUnknownError,
-} from "@/errors";
+} from "@/errors/types/shared/HttpError";
 import {
     classifyHttpError,
     ensureHttpStatus,

--- a/stacks/react-nodejs/frontend/tests/test-utils/index.ts
+++ b/stacks/react-nodejs/frontend/tests/test-utils/index.ts
@@ -1,6 +1,6 @@
 import { Cause, Exit } from "effect";
 
-import { AppError } from "@/errors";
+import { AppError } from "@/errors/types/AppError";
 
 type ExtractByTag<E extends { _tag: string }, T extends string> = E extends { _tag: T } ? E : never;
 


### PR DESCRIPTION
フロントエンドのみ対応
sharedパッケージは保留